### PR TITLE
Fixed SPI initialization and Device Reset

### DIFF
--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -86,14 +86,11 @@ uint8_t PA_TABLE_915[10] {0x03,0x0E,0x1E,0x27,0x38,0x8E,0x84,0xCC,0xC3,0xC0,};  
 void ELECHOUSE_CC1101::SpiStart(void)
 {
   // initialize the SPI pins
-  pinMode(SCK_PIN, OUTPUT);
-  pinMode(MOSI_PIN, OUTPUT);
-  pinMode(MISO_PIN, INPUT);
   pinMode(SS_PIN, OUTPUT);
 
   // enable SPI
   #ifdef ESP32
-  SPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
+  SPI.beginTransaction(SPISettings());
   #else
   SPI.begin();
   #endif
@@ -108,7 +105,6 @@ void ELECHOUSE_CC1101::SpiEnd(void)
 {
   // disable SPI
   SPI.endTransaction();
-  SPI.end();
 }
 /****************************************************************
 *FUNCTION NAME: GDO_Set()
@@ -158,11 +154,13 @@ void ELECHOUSE_CC1101::Reset (void)
 void ELECHOUSE_CC1101::Init(void)
 {
   setSpi();
+  SPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
   SpiStart();                   //spi initialization
   digitalWrite(SS_PIN, HIGH);
   digitalWrite(SCK_PIN, HIGH);
   digitalWrite(MOSI_PIN, LOW);
   Reset();                    //CC1101 reset
+  SpiEnd();
   RegConfigSettings();            //CC1101 register config
   SpiEnd();
 }


### PR DESCRIPTION
* SPI is now initialized only once, when calling Init()
* SPI is no longer being deinitialized after every transaction.

These changes make the CC1101 driver play nice with drivers for other devices on the same SPI bus.